### PR TITLE
Fixing ----max_cluster_bias_DEL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ For more detailed implementation of SV benchmarks, we show an example [here](htt
 	> For PacBio CLR data:
 		--max_cluster_bias_INS		100
 		--diff_ratio_merging_INS	0.3
-		----max_cluster_bias_DEL	200
+		--max_cluster_bias_DEL	200
 		--diff_ratio_merging_DEL	0.5
 
 	> For PacBio CCS(HIFI) data:
 		--max_cluster_bias_INS		1000
 		--diff_ratio_merging_INS	0.9
-		----max_cluster_bias_DEL	1000
+		--max_cluster_bias_DEL	1000
 		--diff_ratio_merging_DEL	0.5
 
 	> For ONT data:
 		--max_cluster_bias_INS		100
 		--diff_ratio_merging_INS	0.3
-		----max_cluster_bias_DEL	100
+		--max_cluster_bias_DEL	100
 		--diff_ratio_merging_DEL	0.3
 	
 | Parameter | Description | Default |


### PR DESCRIPTION
The option was specified with `----` rather than `--` in the suggestions