### PR TITLE
Right size the multiprocess pool for task list size

### DIFF
--- a/src/cuteSV/cuteSV
+++ b/src/cuteSV/cuteSV
@@ -1050,42 +1050,40 @@ def main_ctrl(args, argv):
     candidates["reads_info"]=reads_info_list
     
     atexit.register(cleanup)
-    analysis_pools = Pool(processes=int(args.threads), initializer=init_reading_process, initargs=(args.input, args.reference))
-    os.mkdir("%ssignatures"%temporary_dir)
-    results=[]#use this is faster than make a long paras list
-    for i in range(len(Task_list)):
-        paras = [(args.input, 
-                    args.min_size, 
-                    args.min_mapq, 
-                    args.max_split_parts, 
-                    args.min_read_len, 
-                    temporary_dir, 
-                    Task_list[i], 
-                    args.min_siglength, 
-                    args.merge_del_threshold, 
-                    args.merge_ins_threshold, 
-                    args.max_size,
-                    None if bed_regions == None else bed_regions[i])]
-        analysis_pools.map_async(multi_run_wrapper, paras)
-    pids = [process.pid for process in analysis_pools._pool]
-    analysis_pools.close()
-    analysis_pools.join()
+    with Pool(processes=min(int(args.threads), len(Task_list)), initializer=init_reading_process, initargs=(args.input, args.reference)) as analysis_pools:
+        os.mkdir("%ssignatures"%temporary_dir)
+        sig_results=[]
+        for i in range(len(Task_list)):
+            paras = [(args.input, 
+                        args.min_size, 
+                        args.min_mapq, 
+                        args.max_split_parts, 
+                        args.min_read_len, 
+                        temporary_dir, 
+                        Task_list[i], 
+                        args.min_siglength, 
+                        args.merge_del_threshold, 
+                        args.merge_ins_threshold, 
+                        args.max_size,
+                        None if bed_regions == None else bed_regions[i])]
+            sig_results.append(analysis_pools.map_async(multi_run_wrapper, paras))
+        pids = [process.pid for process in analysis_pools._pool]
+        [r.get() for r in sig_results]
     logging.info("Rebuilding signatures of structural variants.")
 
-    analysis_pools = Pool(processes=int(args.threads))
-    paras=[]
-    for sv_type in SVTYPES:
-        paras.append((sv_type,temporary_dir,pids,args.write_old_sigs))
-    paras.append(("reads",temporary_dir,pids,args.write_old_sigs))
-    results=analysis_pools.map_async(process_process_sigs_type, paras)
-    analysis_pools.close()
-    analysis_pools.join()
-    sigs_index={}
-    for r in results.get():
-        if r!=None:
-            sigs_index[r[0]]=r[1]
-            if r[0]=="reads":
-                sigs_index["reads_count"]=r[2]
+    with Pool(processes=int(args.threads)) as analysis_pools:
+        paras=[]
+        for sv_type in SVTYPES:
+            paras.append((sv_type,temporary_dir,pids,args.write_old_sigs))
+        paras.append(("reads",temporary_dir,pids,args.write_old_sigs))
+        results=analysis_pools.map_async(process_process_sigs_type, paras)
+        sigs_index={}
+        for r in results.get():
+            if r!=None:
+                sigs_index[r[0]]=r[1]
+                if r[0]=="reads":
+                    sigs_index["reads_count"]=r[2]
+
     with open("%s/sigindex.pickle"%temporary_dir,"wb") as f:
         pickle.dump(sigs_index,f)
     del reads_info_list
@@ -1107,96 +1105,93 @@ def main_ctrl(args, argv):
     else:
 
         logging.info("Clustering structural variants.")
-        analysis_pools = Pool(processes=int(args.threads))
+        with Pool(processes=int(args.threads)) as analysis_pools:
 
-        # +++++DEL+++++
-        for chr in sigs_index["DEL"]:
-            para = [(temporary_dir, 
-                    chr, 
-                    "DEL", 
-                    args.min_support,
-                    args.diff_ratio_merging_DEL, 
-                    args.max_cluster_bias_DEL, 
-                    # args.diff_ratio_filtering_DEL, 
-                    min(args.min_support, 5), 
-                    args.input, 
-                    args.genotype,
-                    args.gt_round,
-                    args.remain_reads_ratio,
-                    sigs_index)]
-            result.append(analysis_pools.map_async(run_del, para))
+            # +++++DEL+++++
+            for chr in sigs_index["DEL"]:
+                para = [(temporary_dir, 
+                        chr, 
+                        "DEL", 
+                        args.min_support,
+                        args.diff_ratio_merging_DEL, 
+                        args.max_cluster_bias_DEL, 
+                        # args.diff_ratio_filtering_DEL, 
+                        min(args.min_support, 5), 
+                        args.input, 
+                        args.genotype,
+                        args.gt_round,
+                        args.remain_reads_ratio,
+                        sigs_index)]
+                result.append(analysis_pools.map_async(run_del, para))
 
-        # +++++INS+++++
-        for chr in sigs_index["INS"]:
-            para = [(temporary_dir, 
-                    chr, 
-                    "INS", 
-                    args.min_support, 
-                    args.diff_ratio_merging_INS, 
-                    args.max_cluster_bias_INS, 
-                    # args.diff_ratio_filtering_INS, 
-                    min(args.min_support, 5), 
-                    args.input, 
-                    args.genotype,
-                    args.gt_round,
-                    args.remain_reads_ratio,
-                    sigs_index)]
-            result.append(analysis_pools.map_async(run_ins, para))
+            # +++++INS+++++
+            for chr in sigs_index["INS"]:
+                para = [(temporary_dir, 
+                        chr, 
+                        "INS", 
+                        args.min_support, 
+                        args.diff_ratio_merging_INS, 
+                        args.max_cluster_bias_INS, 
+                        # args.diff_ratio_filtering_INS, 
+                        min(args.min_support, 5), 
+                        args.input, 
+                        args.genotype,
+                        args.gt_round,
+                        args.remain_reads_ratio,
+                        sigs_index)]
+                result.append(analysis_pools.map_async(run_ins, para))
 
-        # +++++INV+++++
-        for chr in sigs_index["INV"]:
-            para = [(temporary_dir, 
-                    chr, 
-                    "INV", 
-                    args.min_support, 
-                    args.max_cluster_bias_INV, 
-                    args.min_size, 
-                    args.input, 
-                    args.genotype, 
-                    args.max_size,
-                    args.gt_round,
-                    sigs_index)]
-            result.append(analysis_pools.map_async(run_inv, para))
+            # +++++INV+++++
+            for chr in sigs_index["INV"]:
+                para = [(temporary_dir, 
+                        chr, 
+                        "INV", 
+                        args.min_support, 
+                        args.max_cluster_bias_INV, 
+                        args.min_size, 
+                        args.input, 
+                        args.genotype, 
+                        args.max_size,
+                        args.gt_round,
+                        sigs_index)]
+                result.append(analysis_pools.map_async(run_inv, para))
 
-        # +++++DUP+++++
-        for chr in sigs_index["DUP"]:
-            para = [(temporary_dir, 
-                    chr, 
-                    args.min_support, 
-                    args.max_cluster_bias_DUP,
-                    args.min_size, 
-                    args.input, 
-                    args.genotype, 
-                    args.max_size,
-                    args.gt_round,
-                    sigs_index)]
-            result.append(analysis_pools.map_async(run_dup, para))
+            # +++++DUP+++++
+            for chr in sigs_index["DUP"]:
+                para = [(temporary_dir, 
+                        chr, 
+                        args.min_support, 
+                        args.max_cluster_bias_DUP,
+                        args.min_size, 
+                        args.input, 
+                        args.genotype, 
+                        args.max_size,
+                        args.gt_round,
+                        sigs_index)]
+                result.append(analysis_pools.map_async(run_dup, para))
 
-        # +++++TRA+++++
-        for chr in sigs_index["TRA"]:
-            para = [(temporary_dir, 
-                    chr, 
-                    args.min_support, 
-                    args.diff_ratio_filtering_TRA, 
-                    args.max_cluster_bias_TRA, 
-                    args.input, 
-                    args.genotype,
-                    args.gt_round,
-                    sigs_index)]
-            result.append(analysis_pools.map_async(run_tra, para))
+            # +++++TRA+++++
+            for chr in sigs_index["TRA"]:
+                para = [(temporary_dir, 
+                        chr, 
+                        args.min_support, 
+                        args.diff_ratio_filtering_TRA, 
+                        args.max_cluster_bias_TRA, 
+                        args.input, 
+                        args.genotype,
+                        args.gt_round,
+                        sigs_index)]
+                result.append(analysis_pools.map_async(run_tra, para))
 
-        analysis_pools.close()
-        analysis_pools.join()
-
-        results={}
-        for res in result:
-            try:
-                chr, svs= res.get()[0]
-                if chr not in results.keys():
-                    results[chr]=[]
-                results[chr].extend(svs)
-            except:
-                logging.info("LocalError: {e}")
+            results={}
+            for res in result:
+                try:
+                    chr, svs= res.get()[0]
+                    if chr not in results.keys():
+                        results[chr]=[]
+                    results[chr].extend(svs)
+                except:
+                    logging.info("LocalError: {e}")
         file = open(args.output, 'w')
         
     logging.info("Writing to your output file.")
@@ -1215,14 +1210,13 @@ def main_ctrl(args, argv):
         os.mkdir("%sresults"%temporary_dir)
         Generation_VCF_header(file, contigINFO, args.sample, argv)
         file.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t%s\n"%(args.sample))
-        analysis_pools = Pool(processes=int(args.threads))
-        paras=[]
-        for chrom in chroms:
-            paras.append((args, results[chrom], args.reference, chrom, temporary_dir))
-        results=analysis_pools.starmap_async(generate_output, paras)
-        analysis_pools.close()
-        analysis_pools.join()
-        results.get()
+        with Pool(processes=int(args.threads)) as analysis_pools:
+            paras=[]
+            for chrom in chroms:
+                paras.append((args, results[chrom], args.reference, chrom, temporary_dir))
+            results=analysis_pools.starmap_async(generate_output, paras)
+            results.get()
+        
         for chrom in chroms:
             if not os.path.exists("%sresults/%s.pickle"%(temporary_dir,chrom)):
                 raise FileNotFoundError("[Errno 2] No such directory: %sresults/%s.pickle"%(temporary_dir,chrom))


### PR DESCRIPTION
This solves #176 by reducing the pool size if there are fewer tasks to run than the total available threads. 

Also moves processing pools to use context manager style and explicitly `get()` all results which might assist in solving/debugging #158 