### PR TITLE
fix: add POS adjustment when 0-based value is used

### DIFF
--- a/src/cuteSV/cuteSV_resolveTRA.py
+++ b/src/cuteSV/cuteSV_resolveTRA.py
@@ -134,8 +134,11 @@ def generate_semi_tra_cluster(semi_tra_cluster, chr_1, chr_2, read_count, overla
 		if len(set(temp[0][2]))+len(set(temp[1][2])) >= len(semi_tra_cluster)*overlap_size:
 			# candidate_single_SV.append("%s\tTRA\t%d\t%s\t%d\t%d\n"%(chr_1, int(temp[0][0]/temp[0][2]), chr_2, int(temp[0][1]/temp[0][2]), len(read_tag)))
 			# candidate_single_SV.append("%s\tTRA\t%d\t%s\t%d\t%d\n"%(chr_1, int(temp[1][0]/temp[1][2]), chr_2, int(temp[1][1]/temp[1][2]), len(read_tag)))
-			BND_pos_1 = "%s:%s"%(chr_2, int(temp[0][1]/len(temp[0][2])))
-			BND_pos_2 = "%s:%s"%(chr_2, int(temp[1][1]/len(temp[1][2])))
+			# BND types A/C encode the mate breakpoint from a 0-based reference_start-derived
+			# coordinate, so it needs +1 to become a valid 1-based VCF position (unlike B/D,
+			# which are already derived from a 1-based-equivalent reference_end coordinate).
+			BND_pos_1 = "%s:%s"%(chr_2, int(temp[0][1]/len(temp[0][2])) + (1 if BND_type in ('A', 'C') else 0))
+			BND_pos_2 = "%s:%s"%(chr_2, int(temp[1][1]/len(temp[1][2])) + (1 if BND_type in ('A', 'C') else 0))
 			if BND_type == 'A':
 				TRA_1 = "N[%s["%(BND_pos_1)
 				TRA_2 = "N[%s["%(BND_pos_2)
@@ -208,7 +211,10 @@ def generate_semi_tra_cluster(semi_tra_cluster, chr_1, chr_2, read_count, overla
 		if len(set(temp[0][2])) >= len(semi_tra_cluster)*overlap_size:
 			# print("%s\tTRA\t%d\t%s\t%d\t%d"%(chr_1, int(temp[0][0]/temp[0][2]), chr_2, int(temp[0][1]/temp[0][2]), len(read_tag)))
 			# candidate_single_SV.append("%s\tTRA\t%d\t%s\t%d\t%d\n"%(chr_1, int(temp[0][0]/temp[0][2]), chr_2, int(temp[0][1]/temp[0][2]), len(read_tag)))
-			BND_pos = "%s:%s"%(chr_2, int(temp[0][1]/len(temp[0][2])))
+			# BND types A/C encode the mate breakpoint from a 0-based reference_start-derived
+			# coordinate, so it needs +1 to become a valid 1-based VCF position (unlike B/D,
+			# which are already derived from a 1-based-equivalent reference_end coordinate).
+			BND_pos = "%s:%s"%(chr_2, int(temp[0][1]/len(temp[0][2])) + (1 if BND_type in ('A', 'C') else 0))
 			if BND_type == 'A':
 				TRA = "N[%s["%(BND_pos)
 			elif BND_type == 'B':


### PR DESCRIPTION
## Fix: invalid mate position (e.g. `chrM:0`) in BND ALT breakend notation

Closes #178 

### Problem

Some BND records emitted by cuteSV contain a mate breakpoint position of `0` in
the ALT bracket notation, e.g.:

```
chr17    22521642    cutesv_cuteSV.BND.6    G    G[chrM:0[
```

A position of `0` is invalid per the VCF spec (all positions, including the
one embedded in breakend ALT notation, must be 1-based and >= 1 - exceptions exist for telomeres but this bug was encountered in references without telomeres).

### Root cause

The mate position embedded in the ALT string (the `chr2:pos` part of
`N[chr:pos[` / `N]chr:pos]` / `[chr:pos[N` / `]chr:pos]N`) is built in
[`generate_semi_tra_cluster()`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_resolveTRA.py#L106-L249)
in `src/cuteSV/cuteSV_resolveTRA.py`, from a breakpoint coordinate that
originates in
[`analysis_bnd()`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV#L97-L188)
in the main `cuteSV` script.

That coordinate is taken from one of two split-read fields depending on
which side of a chimeric alignment produced it:

- `ref_start` — [pysam's `read.reference_start`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV#L610)
  for a primary alignment, or the
  [raw SA-tag `pos`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV#L492)
  for a supplementary segment — **0-based**.
- `ref_end` (pysam's `read.reference_end`, 0-based exclusive) — numerically
  **already equal to the correct 1-based position** of the last aligned
  base, so it needs no adjustment.

`analysis_bnd()` uses these two fields interchangeably across its eight
strand/chromosome-order branches. Concretely, the mate position (the value
that ends up inside the ALT string) is drawn from the 0-based `ref_start`
field specifically for BND types **A** and **C** (the two types whose
notation opens with a `[` bracket) and from the already-correct `ref_end`
field for types **B** and **D**.

The code that assembles the ALT string never applies a `+1` conversion to
that value — contrast this with the primary `POS` column, which explicitly
does [`POS = str(int(i[2]) + 1)`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_genotype.py#L418)
in
[`generate_output()`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_genotype.py#L387-L430)
(`src/cuteSV/cuteSV_genotype.py`). As a result, every BND record of type A
or C reports its mate position one base too low. Most of the time this is a
subtle, easy-to-miss off-by-one; it becomes an invalid `0` whenever
the true 1-based mate position is `1` — which seems common on `chrM`.

**Concrete reproduction:** a read primary-aligned to `chrM` at SAM `POS` 1
has `read.reference_start == 0` (0-based). For a `chr17`/`chrM` pair this is
a type A breakend (`"chr17" < "chrM"`), so this 0-based value flows straight
into the ALT-embedded mate position with no conversion, producing
`chrM:0` instead of the correct `chrM:1`.

### Fix

`src/cuteSV/cuteSV_resolveTRA.py`, `generate_semi_tra_cluster()`: at the
three sites where the mate-position string
([`BND_pos_1`/`BND_pos_2`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_resolveTRA.py#L137-L138),
[`BND_pos`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_resolveTRA.py#L211))
is built, add `+1` when `BND_type` is `A` or `C`. Types `B`/`D`
are left unchanged since their underlying coordinate is already
1-based-equivalent.

### Related issues

- The primary `POS` column has a related, opposite-direction issue: for
  types A/B it is *over*-counted by 1 (and the paired
  [`REF` base lookup](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_genotype.py#L407)
  with it), because the same blanket `+1` in `generate_output()` is applied
  unconditionally regardless of which field the coordinate came from. That
  is a distinct bug with a different fix location (`cuteSV_genotype.py`).
- The internal 0-based/1-based mixing between primary-alignment coordinates
  (pysam, 0-based) and supplementary-alignment coordinates (raw SA tag,
  1-based) is a deeper inconsistency that affects other split-
  read-derived signal types (INV, DUP, INS/DEL from split reads) too. It's
  probably usually masked by cluster-bias tolerances for those types. Should probably be ultimately rectified.

### Code references (upstream `master` @ `03acbd1`)

- [`analysis_bnd()`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV#L97-L188) — builds the raw BND signal tuples, mixing `ref_start`/`ref_end` fields per type
- [`pos_start = read.reference_start`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV#L610) — 0-based primary-alignment coordinate
- [`local_start = int(seq[1])`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV#L492) — 1-based supplementary-alignment coordinate (raw SA tag)
- [`generate_semi_tra_cluster()`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_resolveTRA.py#L106-L249) — builds the ALT breakend string (this PR's fix site)
  - [`BND_pos_1` / `BND_pos_2`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_resolveTRA.py#L137-L138)
  - [`BND_pos`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_resolveTRA.py#L211)
- [`generate_output()` BND branch](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_genotype.py#L387-L430) — writes the final VCF line
  - [`ref_bnd = ref_chrom[int(i[2])]`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_genotype.py#L407) — REF base lookup (part of the out-of-scope `POS` over-count issue)
  - [`POS = str(int(i[2]) + 1)`](https://github.com/tjiangHIT/cuteSV/blob/03acbd19a6906dff5fa143d598523a5285e5d1e9/src/cuteSV/cuteSV_genotype.py#L418) — the `+1` that's applied to `POS` but not to the ALT-embedded mate position
