### PR TITLE
fix: normalize split-read coordinates and correct BND/INV POS off-by-one

### DIFF
--- a/src/cuteSV/cuteSV
+++ b/src/cuteSV/cuteSV
@@ -489,7 +489,12 @@ def organize_split_signal(primary_info, Supplementary_info, total_L, SV_size,
     for i in Supplementary_info:
         seq = i.split(',')
         local_chr = seq[0]
-        local_start = int(seq[1])
+        # SA-tag pos is 1-based (SAM spec), same as the raw POS column of a SAM
+        # record. Convert to 0-based here so it matches read.reference_start,
+        # which is what primary-alignment segments use below. Without this,
+        # a segment's start/end differ by 1 depending on whether it came from
+        # the read's primary record or one of its supplementary records.
+        local_start = int(seq[1]) - 1
         local_cigar = seq[3]
         local_strand = seq[2]
         local_mapq = int(seq[4])

--- a/src/cuteSV/cuteSV_genotype.py
+++ b/src/cuteSV/cuteSV_genotype.py
@@ -350,12 +350,25 @@ def generate_output(args, semi_result, reference, chrom, temporary_dir):
         elif i[1] == "INV":
             if abs(int(float(i[3]))) > args.max_size and args.max_size != -1:
                 continue
-            cal_end = int(i[2]) + 1 + abs(int(float(i[3])))
+            # i[2] (breakpoint_1) originates in analysis_inv() (src/cuteSV/cuteSV) and is
+            # an end-type ref_end coordinate (already a valid 1-based position, since
+            # pysam's reference_end is 0-based-exclusive) for head-to-head ("++")
+            # inversions, but a start-type ref_start coordinate (0-based, needs +1) for
+            # tail-to-tail ("--") inversions. i[7] (the "++"/"--" tag, already carried
+            # through for the INFO STRAND field) tells us which. Compare the equivalent
+            # BND fix above for the mate coordinate and the primary POS column.
+            if i[7] == "++":
+                pos_inv = int(i[2])
+                ref_idx = max(pos_inv - 1, 0)
+            else:
+                pos_inv = int(i[2]) + 1
+                ref_idx = int(i[2])
+            cal_end = pos_inv + abs(int(float(i[3])))
             info_list = "{PRECISION};SVTYPE={SVTYPE};SVLEN={SVLEN};END={END};RE={RE};STRAND={STRAND}{RNAMES}".format(
-                PRECISION = "IMPRECISE" if i[6] == "0/0" else "PRECISE", 
-                SVTYPE = i[1], 
-                SVLEN = i[3], 
-                END = str(cal_end), 
+                PRECISION = "IMPRECISE" if i[6] == "0/0" else "PRECISE",
+                SVTYPE = i[1],
+                SVLEN = i[3],
+                END = str(cal_end),
                 RE = i[4],
                 STRAND = i[7],
                 RNAMES = ";RNAMES=" + i[11] if args.report_readid else "")
@@ -368,13 +381,13 @@ def generate_output(args, semi_result, reference, chrom, temporary_dir):
                 filter_lable = "PASS"
             else:
                 filter_lable = "PASS" if float(i[10]) >= 5.0 else "q5"
-            ref_seq = ref_chrom[int(i[2])]
+            ref_seq = ref_chrom[ref_idx]
             lines.append((i[1],"{CHR}\t{POS}\t{ID}\t{REF}\t{ALT}\t{QUAL}\t{PASS}\t{INFO}\t{FORMAT}\t{GT}:{DR}:{RE}:{PL}:{GQ}\n".format(
-                CHR = i[0], 
-                POS = str(int(i[2]) + 1), 
+                CHR = i[0],
+                POS = str(pos_inv),
                 ID = "cuteSV.%s.<SVID>"%(i[1]),
                 REF = ref_seq.translate(trans_table),
-                ALT = "<%s>"%(i[1]), 
+                ALT = "<%s>"%(i[1]),
                 INFO = info_list, 
                 FORMAT = "GT:DR:DV:PL:GQ", 
                 GT = i[6],
@@ -403,22 +416,37 @@ def generate_output(args, semi_result, reference, chrom, temporary_dir):
                 filter_lable = "PASS"
             else:
                 filter_lable = "PASS" if float(i[10]) >= 5.0 else "q5"
-            try:
-                ref_bnd = ref_chrom[int(i[2])]
-            except:
-                ref_bnd = 'N'
+            # i[2] originates in analysis_bnd() (src/cuteSV/cuteSV) and is a
+            # 0-based ref_start-type coordinate for BND types C/D, but a
+            # ref_end-type coordinate (already a valid 1-based position, since
+            # pysam's reference_end is 0-based-exclusive) for types A/B. Only
+            # the former needs +1 to become a valid 1-based VCF POS; applying
+            # it unconditionally over-counts types A/B by one base, and shifts
+            # the paired REF-base lookup by one base too. Compare the
+            # equivalent BND_pos_1/BND_pos_2 fix in cuteSV_resolveTRA.py for
+            # the mate coordinate embedded in the ALT string.
             if i[1][0] == 'N':
+                # Types A/B
+                pos_bnd = int(i[2])
+                try:
+                    ref_bnd = ref_chrom[max(pos_bnd - 1, 0)]
+                except:
+                    ref_bnd = 'N'
                 alt_bnd = ref_bnd + i[1][1:]
-            elif i[1][-1] == 'N':
-                alt_bnd = i[1][:-1] + ref_bnd
             else:
-                alt_bnd = i[1]
+                # Types C/D (i[1][-1] == 'N'); no other BND_type reaches here
+                pos_bnd = int(i[2]) + 1
+                try:
+                    ref_bnd = ref_chrom[int(i[2])]
+                except:
+                    ref_bnd = 'N'
+                alt_bnd = i[1][:-1] + ref_bnd
             lines.append(("BND","{CHR}\t{POS}\t{ID}\t{REF}\t{ALT}\t{QUAL}\t{PASS}\t{INFO}\t{FORMAT}\t{GT}:{DR}:{RE}:{PL}:{GQ}\n".format(
-                CHR = i[0], 
-                POS = str(int(i[2]) + 1), 
-                ID = "cuteSV.%s.<SVID>"%("BND"), 
+                CHR = i[0],
+                POS = str(pos_bnd),
+                ID = "cuteSV.%s.<SVID>"%("BND"),
                 REF = ref_bnd.translate(trans_table),
-                ALT = alt_bnd, # i[1], 
+                ALT = alt_bnd, # i[1],
                 INFO = info_list, 
                 FORMAT = "GT:DR:DV:PL:GQ", 
                 GT = i[7],


### PR DESCRIPTION
## Fix: BND `POS`/`REF` over-count, and pysam/sam tag 0-based/1-based coordinate mixing

### Background

#179 (merged: [`2196792`](https://github.com/tjiangHIT/cuteSV/commit/2196792)) fixed an invalid `chr2:pos` of `0` in BND ALT breakend notation (e.g. `G[chrM:0[`). While investigating the related issues flagged there — the primary `POS` column being over-counted by 1 for BND types A/B, and the 0-based/1-based mixing of coordinates - it became clear that they are linked and actually can result in the previous fix now causing an off-by-1 error in the opposite direction (coord+1) when the chr2 position is supported by a supplementary alignment, so this PR fixes both issues.

### The issues, and how they interact

1. **Start-vs-end field mixing** (the direct cause of both the original `chr2:pos` bug and the `POS`/`REF` over-count): [`analysis_bnd()`](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L97-L188) picks the mate/primary position from either `ele[2]` (`ref_start`, 0-based) or `ele[3]` (`ref_end`, 0-based-exclusive — numerically already a valid 1-based position) depending on BND type. Types A/C draw from `ref_start` (needs `+1`); types B/D from `ref_end` (already correct). #179 fixed this for the ALT-embedded coordinate; this PR fixes the equivalent problem for the primary `POS` column and its paired `REF` base lookup.
2. **Primary/supplementary coordinate mismatch**: a segment's `ref_start`/`ref_end` come from `read.reference_start`/`reference_end` (pysam, 0-based) when it's the read's primary alignment, but from the raw SA tag `pos` field (SAM spec, 1-based, [never converted](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L492)) when it's a supplementary alignment.
3. **The interaction**: for any BND cluster, contributing reads are averaged together, and which chromosome ends up "primary" vs "supplementary" for a given read is arbitrary (whichever side holds more of that read). This means point `2` doesn't just add imprecision — #179's fix (and this PR's `POS` fix), which are each individually correct for primary-sourced segments, are **incomplete** for supplementary-sourced ones: #179's `+1` for types A/C turns "under-counted by 1" into "correct" for primary-sourced contributions, but into "over-counted by 1" for supplementary-sourced ones, which were *accidentally* correct before #179 (the two bugs canceled out). Fixing point `2` makes #179's fix (and this one) fully correct for every contributing read, not just the primary-sourced subset.
4. **The same start-vs-end mixing bug (point `1`) also exists in INV**: while checking whether DEL/INS/DUP/INV had any analogous problems, found that [`analysis_inv()`](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L50-L94) reports breakpoints from `ele[3]` (end-type, already a valid 1-based position) for head-to-head ("++") inversions, but from `ele[2]` (start-type, needs `+1`) for tail-to-tail ("--") ones. [`generate_output()`'s INV branch](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV_genotype.py#L350-L386) blanket-adds `+1` regardless of orientation — correct for "--", but over-counting `POS` by 1 (and shifting the `REF` base lookup) for "++". The disambiguating tag was available as `i[7]` (used only for the INFO `STRAND=` field) but wasn't keyed on here. 

### Fix

- [`src/cuteSV/cuteSV`](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L492), `organize_split_signal()`: convert the SA-tag `pos` to 0-based (`int(seq[1]) - 1`) so supplementary-sourced segments match the convention primary-sourced segments already use. Since the "end" field is computed as `local_start + span`, this one-line change fixes both `ref_start` and `ref_end` for supplementary segments.
- [`src/cuteSV/cuteSV_genotype.py`](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV_genotype.py#L387-L430), `generate_output()` BND branch: make the `POS` `+1` and the `REF`-base lookup index conditional on BND type, reusing the existing `i[1][0] == 'N'` / `i[1][-1] == 'N'` branch (already present for ALT substitution) that exactly separates {A,B} from {C,D}. Types A/B: `POS = i[2]` (no `+1`), REF at `ref_chrom[i[2]-1]`. Types C/D: unchanged (`POS = i[2]+1`, REF at `ref_chrom[i[2]]`).
- **No change needed** to #179's fix in `cuteSV_resolveTRA.py` — its `+1`-for-types-A/C logic was already correct, it just needed consistently-scaled input, which the `organize_split_signal` fix now provides.
- [`src/cuteSV/cuteSV_genotype.py`](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV_genotype.py#L350-L386), `generate_output()` INV branch: same technique, branching on `i[7]` ("++"/"--") instead of the ALT string. Head-to-head ("++"): `POS = i[2]` (no `+1`), REF at `ref_chrom[i[2]-1]`. Tail-to-tail ("--"): unchanged (`POS = i[2]+1`, REF at `ref_chrom[i[2]]`). `END` (`cal_end`) is now derived as `POS + SVLEN` using the corrected `POS`, rather than independently reapplying the old blanket `+1`.



### Out of scope 

INS has a related but structurally different issue — it averages a start-type and an end-type field together ([`(ele_1[3]+ele_2[2])/2`](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L228), same pattern repeated at [L244](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L244), [L362](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L362), [L385](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L385) and [L415](https://github.com/tjiangHIT/cuteSV/blob/b874ff002600b332d54cac3d1891f4b3e849ecf6/src/cuteSV/cuteSV#L415)) rather than picking one, producing a small, always-in-the-same-direction ~0.5bp bias which affects the `POS`, `INFO/END`, `REF` and `ALT` fields of `INS` calls.  

This is **not** addressed in this PR.